### PR TITLE
Fix signature for URLs that contain colons (`:`)

### DIFF
--- a/www/libs/s3-php/S3.php
+++ b/www/libs/s3-php/S3.php
@@ -1180,7 +1180,7 @@ class S3
 	public static function getAuthenticatedURL($bucket, $uri, $lifetime, $hostBucket = false, $https = false)
 	{
 		$expires = self::__getTime() + $lifetime;
-		$uri = str_replace(array('%2F', '%2B'), array('/', '+'), rawurlencode($uri));
+		$uri = str_replace(array('%2F', '%2B', '%3A'), array('/', '+', ':'), rawurlencode($uri));
 		return sprintf(($https ? 'https' : 'http').'://%s/%s?AWSAccessKeyId=%s&Expires=%u&Signature=%s',
 		// $hostBucket ? $bucket : $bucket.'.s3.amazonaws.com', $uri, self::$__accessKey, $expires,
 		$hostBucket ? $bucket : self::$endpoint.'/'.$bucket, $uri, self::$__accessKey, $expires,


### PR DESCRIPTION
`s3browser` is generating links with the wrong signature if the file path includes a colon.

This can be tested by creating a file `test.txt` and another `text:colons.txt` in the bucket root, and running the project with `S3_SIGNED_URL=true`. The link for `test.txt` works, but the one for `text:colons.txt` results in a `SignatureDoesNotMatch` error.